### PR TITLE
Update README.md for better brew usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,9 @@ For more information, see [Apple's support article on the subject](https://suppo
 With [Homebrew](https://brew.sh/) installed, run the following:
 
 ```sh
-curl -LO https://raw.githubusercontent.com/mklement0/ttab/master/ttab.rb && 
-HOMEBREW_NO_AUTO_UPDATE=1 brew install --formula ttab.rb && 
-rm ttab.rb
+brew tap mklement0/ttab https://github.com/mklement0/ttab.git
+brew install mklement0/ttab/ttab
 ```
-
-<sup>Tip of the hat to [@dsingingwolfboy](https://github.com/singingwolfboy) for inspiring me to add this installation method and providing the original formula, and to [@leemm](https://github.com/leemm) for updating the instructions after Homebrew stopped supporting installing directly from an online `.rb` file.</sup>
 
 Note:
 


### PR DESCRIPTION
The previous way of fetching the brew recipe once, via curl, and loading it locally was not ideal.

The right thing to do is to add the repository as a brew tap.

Closes #49