### PR TITLE
WIP: Tab title not being applied

### DIFF
--- a/bin/ttab
+++ b/bin/ttab
@@ -568,9 +568,14 @@ else # Terminal/iTerm2
     $CMD_SAVE_ACTIVE_TAB
     $CMD_NEWTAB_1
     $CMD_NEWTAB_2
-    $CMD_TITLE
     $CMD_DELAY
     $CMD_CUSTOM
+    $CMD_DELAY
+    $CMD_DELAY
+    $CMD_DELAY
+    $CMD_DELAY
+    $CMD_DELAY
+    $CMD_TITLE
     $CMD_REACTIVATE_PREV_TAB
   end tell
   $CMD_REACTIVATE_PREV_APP


### PR DESCRIPTION
Related to #44, I looked into ANSI escape sequences a bit and (https://github.com/jonathaneunice/iterm2-tab-set/blob/master/tabset.js#L450) but I don't think it's related to the issue I'm having. I'm a Applescript newb but this change managed to set a new tab's title when executing `ttab -t "How Green Was My Valley"` using iTerm2, where it previously wouldn't.